### PR TITLE
Fix parsing of TikZ xcolor mixes (black!10, red!30!blue)

### DIFF
--- a/src/lib/TikzParser.ts
+++ b/src/lib/TikzParser.ts
@@ -86,7 +86,7 @@ const Int = createToken({ name: "Int", pattern: /-?\d+/ });
 const Float = createToken({ name: "Float", pattern: /-?\d+\.\d+/ });
 const Identifier = createToken({ name: "Identifier", pattern: /[0-9a-zA-Z\-']+/ });
 
-const PropertyVal = createToken({ name: "PropertyVal", pattern: /[0-9a-zA-Z<>\-'.]+/ });
+const PropertyVal = createToken({ name: "PropertyVal", pattern: /[0-9a-zA-Z<>\-'.!]+/ });
 
 const allTokens = {
   modes: {
@@ -586,7 +586,7 @@ function isValidPropertyVal(value: string): boolean {
   // return parser.errors.length === 0;
 
   // pattern should be (PropertyVal | Whitespace)+
-  const pattern = /^[0-9a-zA-Z<>\-'. \t\n\r]+$/;
+  const pattern = /^[0-9a-zA-Z<>\-'.! \t\n\r]+$/;
   return pattern.test(value);
 }
 

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -140,4 +140,19 @@ describe("Tikzstyles parser", () => {
     // TODO: fix this. It currently doesn't output the spacing of numbers with unit of measure correctly.
     assert.strictEqual(strip(styles.tikz()), strip(input));
   });
+
+  it("should parse a tikz style with xcolor mix", () => {
+    const input = `\\tikzstyle{dot}=[fill=black!10, draw=red!30!blue]`;
+    const parsed = parseTikzStyles(input);
+    if (parsed.errors.length > 0) {
+      console.error("Parsing errors found:");
+      parsed.errors.forEach(error => {
+        console.error(`${error.line}(${error.column}): ${error.message}`);
+      });
+    }
+    assert.notStrictEqual(parsed.result, undefined);
+    const styles = parsed.result!;
+    assert.strictEqual(strip(styles.tikz()), strip(input));
+  });
 });
+


### PR DESCRIPTION
Fix parsing of TikZ/xcolor styles that use the ! operator (e.g. black!10, red!30!blue).
Updated PropertyVal token and validator regex to accept !, and added a unit test to ensure parsing works correctly.