### PR TITLE
Find figures folder relative to main file or current file instead of workspace folder + allow to create files that do not exist yet

### DIFF
--- a/src/extension/TikzLinkProvider.ts
+++ b/src/extension/TikzLinkProvider.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 export default class TikzLinkProvider implements vscode.DocumentLinkProvider {
   /**
    * Provide document links for \tikzfig{X} and \ctikzfig{X} patterns in LaTeX files.
-   * Creates links to figures/X.tikz files in the workspace.
+   * Creates links to './figures/X.tikz' relative to the main file (obtained from LaTeX Workshop extension) or current file.
    */
   provideDocumentLinks(
     document: vscode.TextDocument,
@@ -12,32 +12,41 @@ export default class TikzLinkProvider implements vscode.DocumentLinkProvider {
   ): vscode.ProviderResult<vscode.DocumentLink[]> {
     const links: vscode.DocumentLink[] = [];
     const text = document.getText();
-
+    
+    // Try to get the root file from LaTeX Workshop (if the extension is not installed or does not return a root file, fall back to current file's directory)
+    let baseDir = path.dirname(document.uri.fsPath);
+    const lwExtension = vscode.extensions.getExtension('james-yu.latex-workshop');
+    if (lwExtension?.isActive) {
+      const lwApi = lwExtension.exports;
+      const rootFile = lwApi?.manager?.rootFile;
+      if (typeof rootFile === "string" && rootFile.length) {
+        baseDir = path.dirname(rootFile);
+      }
+    }
+    
+    // Look for figures folder relative to the base directory
+    const figuresDir = path.join(baseDir, "figures");
+    
     // Regular expression to match \tikzfig{filename} or \ctikzfig{filename}
-    // Captures the filename in group 1
     const regex = /\\c?tikzfig\{([^}]+)\}|"tikzcache\/([^"]+).svg"/g;
-
     let match;
+    
     while ((match = regex.exec(text)) !== null) {
       const filename = match[1] || match[2];
       const startPos = document.positionAt(match.index);
       const endPos = document.positionAt(match.index + match[0].length);
       const range = new vscode.Range(startPos, endPos);
-
+      
       // Create URI for the corresponding tikz file
       const tikzFileName = `${filename}.tikz`;
-      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
-
-      if (workspaceFolder) {
-        const tikzFilePath = path.join(workspaceFolder.uri.fsPath, "figures", tikzFileName);
-        const tikzFileUri = vscode.Uri.file(tikzFilePath);
-
-        const link = new vscode.DocumentLink(range, tikzFileUri);
-        link.tooltip = `Open ${tikzFileName}`;
-        links.push(link);
-      }
+      const tikzFilePath = path.join(figuresDir, tikzFileName);
+      const tikzFileUri = vscode.Uri.file(tikzFilePath);
+      
+      const link = new vscode.DocumentLink(range, tikzFileUri);
+      link.tooltip = `Open ${tikzFileName}`;
+      links.push(link);
     }
-
+    
     return links;
   }
 }

--- a/src/extension/TikzLinkProvider.ts
+++ b/src/extension/TikzLinkProvider.ts
@@ -12,10 +12,10 @@ export default class TikzLinkProvider implements vscode.DocumentLinkProvider {
   ): vscode.ProviderResult<vscode.DocumentLink[]> {
     const links: vscode.DocumentLink[] = [];
     const text = document.getText();
-    
+
     // Try to get the root file from LaTeX Workshop (if the extension is not installed or does not return a root file, fall back to current file's directory)
     let baseDir = path.dirname(document.uri.fsPath);
-    const lwExtension = vscode.extensions.getExtension('james-yu.latex-workshop');
+    const lwExtension = vscode.extensions.getExtension("james-yu.latex-workshop");
     if (lwExtension?.isActive) {
       const lwApi = lwExtension.exports;
       const rootFile = lwApi?.manager?.rootFile;
@@ -23,30 +23,34 @@ export default class TikzLinkProvider implements vscode.DocumentLinkProvider {
         baseDir = path.dirname(rootFile);
       }
     }
-    
+
     // Look for figures folder relative to the base directory
     const figuresDir = path.join(baseDir, "figures");
-    
+
     // Regular expression to match \tikzfig{filename} or \ctikzfig{filename}
     const regex = /\\c?tikzfig\{([^}]+)\}|"tikzcache\/([^"]+).svg"/g;
     let match;
-    
+
     while ((match = regex.exec(text)) !== null) {
       const filename = match[1] || match[2];
       const startPos = document.positionAt(match.index);
       const endPos = document.positionAt(match.index + match[0].length);
       const range = new vscode.Range(startPos, endPos);
-      
+
       // Create URI for the corresponding tikz file
       const tikzFileName = `${filename}.tikz`;
       const tikzFilePath = path.join(figuresDir, tikzFileName);
       const tikzFileUri = vscode.Uri.file(tikzFilePath);
-      
-      const link = new vscode.DocumentLink(range, tikzFileUri);
+
+      // Use a command URI so clicking can prompt to create the file if it doesn't exist.
+      const cmdArgs = encodeURIComponent(JSON.stringify([tikzFileUri.fsPath]));
+      const cmdUri = vscode.Uri.parse(`command:vstikzit.openOrCreateTikz?${cmdArgs}`);
+
+      const link = new vscode.DocumentLink(range, cmdUri);
       link.tooltip = `Open ${tikzFileName}`;
       links.push(link);
     }
-    
+
     return links;
   }
 }
@@ -56,7 +60,6 @@ export default class TikzLinkProvider implements vscode.DocumentLinkProvider {
  */
 export function registerTikzLinkProvider(context: vscode.ExtensionContext): void {
   const provider = new TikzLinkProvider();
-
   // Register for TeX and HTML files
   const latexSelector = [
     { language: "latex", scheme: "file" },


### PR DESCRIPTION
Two updates:
- The figures folder is not found relative to the main file (as given by LaTeX Workshop) or simply the current file's directory. I think this better mimicks the behaviour of the tikzit package.
- You can click on a tikz file even if it does not exist and it will ask to create it for you.